### PR TITLE
fix: remove pleasantries

### DIFF
--- a/content/there-was-an-error-accepting-invite-please-contact-the-sites-administrator.md
+++ b/content/there-was-an-error-accepting-invite-please-contact-the-sites-administrator.md
@@ -5,4 +5,4 @@ tags:
   - settings
   - error
 ---
-There was an error accepting invite. Please contact the site's administrator.
+There was an error accepting invite. Contact the site's administrator.


### PR DESCRIPTION
This is an opinionated suggestion, happy for it to be ignored. I'd recommend omitting the word "please" in copy as a soft rule. 

Please is used widely, but oftentimes it's just an extra word that doesn't add anything. Does a reader _really_ ever think "Hmm, this user interface is being so rude to me" when a plain instruction is given? I think this suggestion is inline with [Material Design's recommendations](https://material.io/design/communication/writing.html) _Click continue_ vs _Please click continue_ etc